### PR TITLE
metainfo: Add custom key "GnomeSoftware::requires-akmods-key"

### DIFF
--- a/xorg-x11-drv-nvidia.metainfo.xml
+++ b/xorg-x11-drv-nvidia.metainfo.xml
@@ -46,4 +46,7 @@
   </keywords>
   <url type="bugtracker">https://bugzilla.rpmfusion.org</url>
   <update_contact>xorg-x11-drv-nvidia-owner@rpmfusion.org</update_contact>
+  <custom>
+    <value key="GnomeSoftware::requires-akmods-key">True</value>
+  </custom>
 </component>


### PR DESCRIPTION
This is related to a gnome-software change [1] and it had been mentioned at [2] as well. The updated gnome-software will provide special functionality in systems with Secure Boot enabled, it'll ensure the akmods key is ready in the UEFI, thus any drivers using akmods and signed by this akmods key will be used by the kernel.

[1] https://gitlab.gnome.org/GNOME/gnome-software/-/merge_requests/2034  
[2] https://bugzilla.rpmfusion.org/show_bug.cgi?id=6976