### PR TITLE
Update power management rules

### DIFF
--- a/80-nvidia-pm.rules
+++ b/80-nvidia-pm.rules
@@ -1,3 +1,12 @@
+# Remove NVIDIA USB xHCI Host Controller devices, if present
+ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x0c0330", ATTR{remove}="1"
+
+# Remove NVIDIA USB Type-C UCSI devices, if present
+ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x0c8000", ATTR{remove}="1"
+
+# Remove NVIDIA Audio devices, if present
+ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x040300", ATTR{remove}="1"
+
 # Enable runtime PM for NVIDIA VGA/3D controller devices on driver bind
 ACTION=="bind", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x030000", TEST=="power/control", ATTR{power/control}="auto"
 ACTION=="bind", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x030200", TEST=="power/control", ATTR{power/control}="auto"


### PR DESCRIPTION
It's just the last version of https://download.nvidia.com/XFree86/Linux-x86_64/550.78/README/dynamicpowermanagement.html

It also fixes a very specific problem related to Nvidia suspension in my laptop, which uses Nvidia Prime:

```
# Everything fine, Nvidia card suspension works as expected
echo 1 > /sys/module/snd_hda_intel/parameters/power_save_controller

# Change the parameter and call nvidia-smi just to wake it up
# the card won't go back to suspension
echo 0 > /sys/module/snd_hda_intel/parameters/power_save_controller
nvidia-smi

# Changing back the option won't make any difference, a reboot is needed
echo 1 > /sys/module/snd_hda_intel/parameters/power_save_controller
```

More details at https://github.com/redhat-performance/tuned/issues/649


Let me know if you can't reproduce it or if this is not the right place to propose the change.




