### PR TITLE
Make the nvidia driver is loaded

### DIFF
--- a/xorg-x11-drv-nvidia.spec
+++ b/xorg-x11-drv-nvidia.spec
@@ -10,7 +10,7 @@
 %global        _firmwarepath        %{_prefix}/lib/firmware
 %global        _winedir             %{_libdir}/nvidia/wine
 %global        _dracutopts          rd.driver.blacklist=nouveau,nova_core modprobe.blacklist=nouveau,nova_core
-%global        _dracutopts_removed  initcall_blacklist=simpledrm_platform_driver_init nvidia-drm.modeset=1 nvidia-drm.fbdev=1
+%global        _dracutopts_removed  initcall_blacklist=simpledrm_platform_driver_init
 %if 0%{?rhel}
 %global        _systemd_util_dir    %{_prefix}/lib/systemd
 %endif


### PR DESCRIPTION
The nouveau module is always loaded, because the nvidia driver isn't being loaded on boot: https://github.com/rpmfusion/xorg-x11-drv-nvidia/blob/master/nvidia-fallback.service

I always get `NVIDIA kernel module missing. Falling back to nouveau`.

Why is `nvidia-drm.fbdev=1` also disabled? To my knowledge, this is needed for proper Wayland support.