### PR TITLE
Provide proper conflicts on more subpackages

### DIFF
--- a/xorg-x11-drv-nvidia.spec
+++ b/xorg-x11-drv-nvidia.spec
@@ -20,6 +20,16 @@
 %global        __brp_ldconfig %{nil}
 %undefine      _missing_build_ids_terminate_build
 
+%define nv_provide_conflict(s:) \
+Conflicts:       xorg-x11-drv-nvidia%{-s*} > %{?epoch}:%{version} \
+Provides:        xorg-x11-drv-nvidia%{-s*} = %{?epoch}:%{version} \
+Obsoletes:       xorg-x11-drv-nvidia%{-s*} < %{?epoch}:%{version}
+%define nv_serie_conflict(s:) \
+Conflicts:       xorg-x11-drv-nvidia-340xx%{-s*} \
+Conflicts:       xorg-x11-drv-nvidia-390xx%{-s*} \
+Conflicts:       xorg-x11-drv-nvidia-470xx%{-s*} \
+Conflicts:       xorg-x11-drv-nvidia-580xx%{-s*}
+
 Name:            xorg-x11-drv-nvidia
 Epoch:           3
 Version:         610.43.02
@@ -75,10 +85,10 @@ Obsoletes:       %{_nvidia_serie}-kmod < %{?epoch}:%{version}
 Provides:        %{_nvidia_serie}-kmod-common = %{?epoch}:%{version}
 # Support nvidia-open-kmod
 Provides:        %{_nvidia_serie}-open-kmod-common = %{?epoch}:%{version}
-Conflicts:       xorg-x11-drv-nvidia-340xx
-Conflicts:       xorg-x11-drv-nvidia-390xx
-Conflicts:       xorg-x11-drv-nvidia-470xx
-Conflicts:       xorg-x11-drv-nvidia-580xx
+Provides:        nvidia-open-kmod-common = %{?epoch}:%{version}
+Obsoletes:       nvidia-open-kmod-common < %{?epoch}:%{version}
+%{nv_serie_conflict}
+%{nv_provide_conflict}
 
 %global         __provides_exclude ^(lib.*GL.*\\.so.*)$
 %global         __requires_exclude ^libglxserver_nvidia.so|^(lib.*GL.*\\.so.*)$
@@ -121,10 +131,8 @@ Requires:        nvidia-modprobe%{?_isa} = %{?epoch}:%{version}
 Requires:        (%{name}-cuda-libs(x86-32) = %{?epoch}:%{version}-%{release} if mesa-libGL(x86-32))
 %endif
 
-Conflicts:       xorg-x11-drv-nvidia-340xx-cuda
-Conflicts:       xorg-x11-drv-nvidia-390xx-cuda
-Conflicts:       xorg-x11-drv-nvidia-470xx-cuda
-Conflicts:       xorg-x11-drv-nvidia-580xx-cuda
+%{nv_serie_conflict -s -cuda}
+%{nv_provide_conflict -s -cuda}
 
 Provides:        cuda-drivers-%(echo %{version} | cut -f 1 -d .) = %{?epoch}:%{version}
 Provides:        cuda-drivers = %{?epoch}:%{version}.100
@@ -151,6 +159,7 @@ Requires:        opencl-filesystem
 # Don't depend on any ICD-LOADER implementation - rhbz#2375547#c2
 Requires:        libOpenCL.so.1()(64bit)
 %endif
+%{nv_provide_conflict -s -cuda-libs}
 
 %description cuda-libs
 This package provides the CUDA driver libraries.
@@ -196,6 +205,8 @@ Requires:        (%{name}-libs(x86-32) = %{?epoch}:%{version}-%{release} if mesa
 Requires:        mesa-libEGL%{?_isa}
 Requires:        mesa-libGL%{?_isa}
 Requires:        mesa-libGLES%{?_isa}
+%{nv_serie_conflict -s -libs}
+%{nv_provide_conflict -s -libs}
 
 
 %description libs
@@ -209,6 +220,7 @@ Requires:       xserver-abi(videodrv-25)
 Requires:       xorg-x11-xinit%{?_isa}
 # Needed so nvidia-settings can write broken configs
 Suggests:       nvidia-xconfig%{?_isa} = %{?epoch}:%{version}
+%{nv_provide_conflict -s -xorg-libs}
 
 %description xorg-libs
 This package provides the Xorg libraries for %{name}.


### PR DESCRIPTION
libs package did not conflict explicitly, but the provided files conflict. Simplify replacing one driver serie with another. Make dnf install --allowerasing likely to work when switching to different version.