### PR TITLE
fix: wire %{_dracutopts_removed} into %preun and %posttrans so legacy cmdline args are cleaned up on upgrade/uninstall

### DIFF
--- a/xorg-x11-drv-nvidia.spec
+++ b/xorg-x11-drv-nvidia.spec
@@ -467,6 +467,7 @@ if [ "$1" -eq "1" ]; then
 fi
 
 %posttrans
+%{_grubby} --remove-args='%{_dracutopts_removed}' &>/dev/null || :
 if [ "$1" -eq "1" ]; then
   %{_grubby} --remove-args='nomodeset' --args='%{_dracutopts}' &>/dev/null
 # EL8 still requires a grub2-mkconfig call
@@ -481,7 +482,7 @@ fi || :
 
 %preun
 if [ "$1" -eq "0" ]; then
-  %{_grubby} --remove-args='%{_dracutopts}' &>/dev/null
+  %{_grubby} --remove-args='%{_dracutopts} %{_dracutopts_removed}' &>/dev/null
   # Backup and disable previously used xorg.conf
   [ -f %{_sysconfdir}/X11/xorg.conf ] && mv %{_sysconfdir}/X11/xorg.conf %{_sysconfdir}/X11/xorg.conf.nvidia_uninstalled &>/dev/null
   # EL8 still requires a grub2-mkconfig call


### PR DESCRIPTION
## Problem

`%global _dracutopts_removed` is defined at spec:13 with three kernel arguments:

```
initcall_blacklist=simpledrm_platform_driver_init nvidia-drm.modeset=1 nvidia-drm.fbdev=1
```

A `grep -n '_dracutopts_removed'` across all live branches (master, f43, f42, el10) returns exactly one hit on each — the definition itself. The macro has no consumer in any scriptlet.

**History:** the global was introduced in `bb1a8cf` (2024-08-21, rfbz#7034 fix) alongside a `%triggerun` that called `--remove-args='%{_dracutopts_removed}'`. That trigger was reused in `dfca1d8` (2025-06-11, "Update scriptlets to blacklist nova-core") to push the new nova_core args via `--args`, and the `--remove-args` call was dropped without being re-homed. `bed51d5` / `baf9ee6` then deleted the trigger mechanism entirely as part of the `%post → %posttrans` switch, leaving the global fully orphaned.

**Effect on %preun (uninstall path):** `spec:484` calls:
```
%{_grubby} --remove-args='%{_dracutopts}'
```
`%{_dracutopts}` contains only the nouveau/nova_core blacklist args. `initcall_blacklist=simpledrm_platform_driver_init` is not in it, is removed by nothing else on the uninstall path, and so survives `dnf remove *nvidia*`. Since `CONFIG_DRM_SIMPLEDRM=y` is built-in on Fedora, that argument permanently disables the only generic KMS console fallback. The argument propagates into every subsequently installed kernel via the bootloader cmdline, affecting kernels installed after the NVIDIA packages are gone.

**Effect on %posttrans (upgrade path):** the `%posttrans` grubby call runs only under `if [ "$1" -eq "1" ]` (fresh install). Upgrades never trigger any removal of the legacy args.

This is distinct from rfbz#7034. That fix migrated off `/etc/default/grub` sed-editing and placed legacy-arg cleanup inside a version-guarded `%triggerun` — its only change to `%preun` was deleting a `sed` line. A `%triggerun` guard is one-shot and never fires for anyone already at or above the guard version. It no longer exists at all.

## Fix

Two-hunk patch — both are needed to cover (a) the upgrade path and (b) the uninstall path.

```diff
--- a/xorg-x11-drv-nvidia.spec
+++ b/xorg-x11-drv-nvidia.spec
@@ -469,6 +469,7 @@ fi
 %posttrans
+%{_grubby} --remove-args='%{_dracutopts_removed}' &>/dev/null || :
 if [ "$1" -eq "1" ]; then
   %{_grubby} --remove-args='nomodeset' --args='%{_dracutopts}' &>/dev/null

@@ -483,7 +484,7 @@ fi
 %preun
 if [ "$1" -eq "0" ]; then
-  %{_grubby} --remove-args='%{_dracutopts}' &>/dev/null
+  %{_grubby} --remove-args='%{_dracutopts} %{_dracutopts_removed}' &>/dev/null
```

The unconditional `--remove-args` at the top of `%posttrans` replaces the one-shot trigger for the upgrade path; the `%preun` hunk closes the uninstall gap that has been open since bb1a8cf.

Tested by inspection on master (610.57.04-1), f43, f42, el10.

Bug report: https://bugzilla.rpmfusion.org/show_bug.cgi?id=7535 (rfbz#7535)
See also: https://bugzilla.rpmfusion.org/show_bug.cgi?id=7034 (rfbz#7034)
